### PR TITLE
Updated gulp-if to version 2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "del": "2.0.2",
     "front-matter": "1.0.0",
     "gulp": "3.9.0",
-    "gulp-if": "1.2.5",
+    "gulp-if": "2.0.0",
     "gulp-less": "3.0.3",
     "gulp-livereload": "3.8.1",
     "gulp-plumber": "1.0.1",


### PR DESCRIPTION
:rocket:

gulp-if just published version 2.0.0, so that’s now up to date in your `package.json`.

Check that it doesn’t break your code and release the new version of your software safe in the knowledge that it will stay in this working state.

---
The new version differs by 8 commits (ahead by 8, behind by 0).

- [16b1aae](https://github.com/robrich/gulp-if/commit/16b1aaeb8041b1b3368e1b1dbcb3acf5cea5ac01): update dependencies, bump version: major version because of minimatch@3 and duplexer moving to streams3
- [c7f895e](https://github.com/robrich/gulp-if/commit/c7f895ec0ef8d0a9614e5a61070afebb4fa626eb): Tests that validate gulp-if works for 10, 100, 200, and 400 files.  Does this solve #43?
- [3279207](https://github.com/robrich/gulp-if/commit/32792078adda70c0a4c5a0254b088ea4d483a06d): update dependencies, bump version: major version because of minimatch@3 and duplexer moving to streams3
- [54550ad](https://github.com/robrich/gulp-if/commit/54550add63670d801d7776486512dbb6e46147c7): Support passing minimatch options through gulp-match
- [258e68d](https://github.com/robrich/gulp-if/commit/258e68d395389f9eb5ff9ecf44346ca69d25ee59): Merge pull request #54 from dkoleary88/patch-1
- [9b11a70](https://github.com/robrich/gulp-if/commit/9b11a7024734eafd2a01ab8c7a616bfa59a83875): Fixed spelling error in README.md
- [543354f](https://github.com/robrich/gulp-if/commit/543354f58d4ffa0bf64fc2f5f22b18b2def040bd): Merge pull request #50 from pgilad/patch-1
- [10493e9](https://github.com/robrich/gulp-if/commit/10493e99576d7b5967e57a4f08955550654f7e38): update license attribute

See the [full diff](https://github.com/robrich/gulp-if/compare/45aab7a6d203adae8fb7c68221ea49b709754b84...16b1aaeb8041b1b3368e1b1dbcb3acf5cea5ac01).

---
This pull request was created by [greenkeeper.io](http://greenkeeper.io/).
It keeps your software, up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>